### PR TITLE
Correction d'une faute de frappe

### DIFF
--- a/2sucres-auto-refresh.user.js
+++ b/2sucres-auto-refresh.user.js
@@ -4,11 +4,11 @@
 // @updateURL    https://github.com/sucresware/2sucres-auto-refresh/raw/master/2sucres-auto-refresh.user.js
 // @downloadURL  https://github.com/sucresware/2sucres-auto-refresh/raw/master/2sucres-auto-refresh.user.js
 // @author		 SucresWare
-// @version      1.2
+// @version      1.3
 // @match        https://2sucres.org/*
 // ==/UserScript==
 
-var refreshRate = 100;
+var refreshRate = 1000;
 var requestsCount = 0;
 var refreshInterval = null;
 var refreshElement = null;


### PR DESCRIPTION
Ajout d'un zéro oublié à la variable refreshRate qui causait un rafraîchissement trop rapide, atteignant la lourde charge de 10 requêtes par secondes pour l'API de 2Sucres, et rendant ainsi le script similaire à une exploitation de faille selon Jérémy.